### PR TITLE
Updated Makefile to reflect dependency order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 kcamera: $(OBJ_FILES)
 	@mkdir -p $(BIN_DIR)
-	g++ $(LDFLAGS) -o $(BIN_DIR)/$@ $^
+	g++ -o $(BIN_DIR)/$@ $^ $(LDFLAGS)
 
 clean:
 	\rm -rf $(BUILD_DIR) $(BIN_DIR)


### PR DESCRIPTION
The current Makefile will fail to run with newer Ubuntu distributions (and potentially others) where g++ parameter order matters. Dependencies are loaded in a "rolling" fashion, eg. source A depending on source B must come earlier in the sequence.

Additionally, making a NB that with Linux the Halide Makefile does not copy libHalide.so into a PATH location (unlike with MacOS), so users should remember to either append 
`LD_LIBRARY_PATH=../Halide/bin ./bin/kcamera scenes/taxi.bin out.bmp`
or copy/link libHalide.so to `/usr/local/lib`, etc